### PR TITLE
Edit building scenes doc

### DIFF
--- a/_posts/documentation/building-scenes/2018-01-04-entities.md
+++ b/_posts/documentation/building-scenes/2018-01-04-entities.md
@@ -11,25 +11,32 @@ set_order: 4
 
 
 
-## Basics
+## Entities and Components
 
-Here are all of the currently supported elements, or entities, that you can use to create three dimensional scenes in Decentraland.
+Three dimensional scenes in Decentraland are based on the [Entity-Component](https://en.wikipedia.org/wiki/Entity%E2%80%93component%E2%80%93system) model, where everything in a scene is an *entity*, and each entity can include *components* that shape its characteristics and functionality. 
 
-## Entity
+`<entity>` is the base element of Decentraland, all elements are built by extending the base `entity` object. An `<entity>` can contain several components, each component introduces attributes that modify the entity in different ways. For example, you can include the `color` component on an entity to set its color, or include the `ignoreCollision` component to change how it reponds to collisions with other entities.
 
-`<entity>` is the base element of Decentraland. It acts as a container object that can be positioned, scaled, and rotated. The `<entity>` element can contain a set of components that might modify the base entity. For example, you can include the `color` component to change the color of your base `<entity>`.
 
-Entities may contain other child entities; those children are scaled, rotated, and positioned relative to the parent entity.
+You can use the plain `<entity>` element in a scene to act as a container. The `<entity>` element has no components by default, so it isn't visible and has no direct effect on the scene, but it can be positioned, scaled, and rotated and it can contain other child entities in it. Child entities are scaled, rotated, and positioned relative to the parent entity. 
 
-## Possible components
+Entities with no components can also be added to a scene to group entities into a single object that can then be passed as an input for certain functions.
 
-Here we will describe the interfaces to create every entity for Decentraland.
+
+Below, we describe all the interfaces that can be used to create specific kinds of entities in Decentraland. Each of these interfaces allows you to define a limited series of components that modify the entity.
+
+
+
+## Base Entity
+
+
+The `BaseEntity` interface is the most flexible of all, as it lets you set values for any of the possible components.
 
 ```tsx
 
 interface BaseEntity {
   /**
-   * Moves the entity center to that point
+   * Moves the entity center to a given point in the scene or relative to a parent entity
    */
   position?: Vector3
 
@@ -71,14 +78,14 @@ interface BaseEntity {
 
   /**
    * Billboard defines a behavior that makes the entity face the camera in any moment.
-   * There are three combinable types of camera facing options defined in the object BillboardModes.
+   * There are three combinable types of camera-facing options defined in the object BillboardModes.
    *   BILLBOARDMODE_NONE: 0
    *   BILLBOARDMODE_X: 1
    *   BILLBOARDMODE_Y: 2
    *   BILLBOARDMODE_Z: 4
    *   BILLBOARDMODE_ALL: 7
    *
-   * To combine billboard types write those in the form:
+   * To combine billboard types, write those in the form:
    *   BillboardModes.BILLBOARDMODE_X | BillboardModes.BILLBOARDMODE_Y
    */
   billboard?: IBillboardModes
@@ -141,7 +148,7 @@ type TimingFunction =
 
 ## Box
 
-Creates a cube geometry
+Creates a cube geometry.
 
 ```tsx
 interface BoxEntity extends BaseEntity {
@@ -158,7 +165,7 @@ const example = <box position={vector} color="#ff00aa" scale={2} />
 
 ## Sphere
 
-Creates a sphere geometry
+Creates a sphere geometry.
 
 ```tsx
 interface SphereEntity extends BaseEntity {
@@ -301,24 +308,25 @@ const example =
 
 ### Why use glTF?
 
-In comparison to the older OBJ format, which supports only vertices, normals, texture coordinates, and basic materials,
-glTF provides a more powerful set of features. In addition to all of the above, glTF offers:
+Compared to the older *OBJ format*, which supports only vertices, normals, texture coordinates, and basic materials,
+glTF provides a more powerful set of features. In addition to all of the features we just named, glTF also offers:
 
 - Hierarchical objects
 - Scene information (light sources, cameras)
 - Skeletal structure and animation
 - More robust materials and shaders
 
-For simple models with no animation, OBJ is nevertheless a common and reliable choice.
+For simple models that have no animations, OBJ is still a common and reliable choice.
 
-In comparison to COLLADA, the supported features are very similar. However, because glTF focuses on providing a
+Compared to *COLLADA*, the supported features are very similar. However, because glTF focuses on providing a
 "transmission format" rather than an editor format, it is more interoperable with web technologies.
-By analogy, the .PSD (Adobe Photoshop) format is helpful for editing 2D images, but images are converted to .JPG for use
-on the web. In the same way, glTF is a simpler way of transmitting 3D assets while rendering the same result.
+
+Consider this analogy: the .PSD (Adobe Photoshop) format is helpful for editing 2D images, but images must then be converted to .JPG for use
+on the web. In the same way, COLLADA may be used to edit a 3D asset, but glTF is a simpler way of transmitting it while rendering the same result.
 
 ## Obj
 
-We only support `obj-model` for legacy compatibility. We will probably get rid of it in the future, please use GLTF when
+We only support the `obj-model` interface for legacy compatibility. We will probably get rid of it in the future, please use GLTF when
 possible.
 
 ```tsx


### PR DESCRIPTION
review and merge

Question:
At one point we say "For simple models that have no animations, OBJ is still a common and reliable choice." but then we say that the Obj interface is going to be removed in the future. Should we remove that first mention? Or are we saying that what will be deprecated is just the "obj-model` interface, but that there will still be other ways to use OBJ models?

I also feel like it's worth adding something about creating custom interfaces for creating entities. I want to add that in the future.