### PR TITLE
Fix code samples

### DIFF
--- a/_posts/documentation/building-scenes/2018-01-03-create-scene.md
+++ b/_posts/documentation/building-scenes/2018-01-03-create-scene.md
@@ -84,6 +84,7 @@ Since the root scene element is a transform node, it can also be translated, sca
 
 This file contains the code that generates an entity tree, which is what end users of your parsel will see. Below is a basic example of a `scene.tsx` file:
 
+{% raw %}
 ```tsx
 import { ScriptableScene, createElement } from "metaverse-api";
 
@@ -92,12 +93,13 @@ export default class MyScene extends ScriptableScene<any, any> {
   async render() {
     return (
       <scene>
-        <box position={ { x: 5, y: 0, z: 5 } } scale={ { x: 1, y: 1, z: 1 } } />
+        <box position={{ x: 5, y: 0, z: 5 }} scale={{ x: 1, y: 1, z: 1 }} />
       </scene>
     );
   }
 }
 ```
+{% endraw %}
 
 > **Important note:** Your `scene.tsx` must always include an `export default class`, that's how our SDK finds the class to initialize the scene.
 

--- a/_posts/sdk-reference/2018-01-03-event-handling.md
+++ b/_posts/sdk-reference/2018-01-03-event-handling.md
@@ -54,8 +54,8 @@ export default class LastClicked extends ScriptableScene {
   async render() {
     return (
       <scene>
-        <box id="box1" position={{ x: 2, y: 1, z: 0 }} color="ff0000" />
-        <box id="box2" position={{ x: 4, y: 1, z: 0 }} color="00ff00" />
+        <box id="box1" position={ { x: 2, y: 1, z: 0 } } color="ff0000" />
+        <box id="box2" position={ { x: 4, y: 1, z: 0 } } color="00ff00" />
       </scene>
     )
   }
@@ -122,7 +122,7 @@ export default class bigButton extends ScriptableScene {
     return (
       <scene>
           <box id="button" 
-              position={{ x: 3, y: this.state.buttonState, z: 3 }} 
+              position={ { x: 3, y: this.state.buttonState, z: 3 } } 
               transition={ { position: { duration: 200, timing: "linear" } } } 
           />
       </scene>
@@ -161,7 +161,7 @@ export default class BoxFollower extends ScriptableScene {
   async render() {
     return (
       <scene>
-        <box position={this.state.boxPosition} ignoreCollisions />
+        <box position= {this.state.boxPosition} ignoreCollisions />
       </scene>
     )
   }
@@ -199,7 +199,7 @@ export default class ConeHead extends ScriptableScene {
   async render() {
     return (
       <scene>
-      <cone position={{ x: 0, y: 1, z: 2 }} rotation={this.state.rotation}/>
+      <cone position={ { x: 0, y: 1, z: 2 } } rotation={this.state.rotation}/>
       </scene>
     )
   }

--- a/_posts/sdk-reference/2018-01-03-event-handling.md
+++ b/_posts/sdk-reference/2018-01-03-event-handling.md
@@ -36,6 +36,7 @@ The generic `click` event represents all clicks done on valid entities. The even
 * `elementId`: the Id of the entity that was clicked.
 * `pointerId`: the id for the user who performed the click.
 
+{% raw %}
 ```tsx
 import { createElement, ScriptableScene } from 'metaverse-api'
 
@@ -54,13 +55,14 @@ export default class LastClicked extends ScriptableScene {
   async render() {
     return (
       <scene>
-        <box id="box1" position={ { x: 2, y: 1, z: 0 } } color="ff0000" />
-        <box id="box2" position={ { x: 4, y: 1, z: 0 } } color="00ff00" />
+        <box id="box1" position={{ x: 2, y: 1, z: 0 }} color="ff0000" />
+        <box id="box2" position={{ x: 4, y: 1, z: 0 }} color="00ff00" />
       </scene>
     )
   }
 }
 ```
+{% endraw %}
 
 The example above uses the `subscribeTo` to initiate a listener that checks for all click events. When the user clicks on either of the two boxes, the scene stores the id of the clicked entity in the `lastClicked` state variable and prints it to console.
 
@@ -70,6 +72,7 @@ A simpler way to deal with clicks that are done on a single entity is to listen 
 
 > Note:Entity-specific click events have no properties, so you can't access the user's id from this event.
 
+{% raw %}
 ```tsx
 import { createElement, ScriptableScene } from 'metaverse-api'
 
@@ -94,6 +97,7 @@ export default class RedButton extends ScriptableScene {
   }
 }
 ```
+{% endraw %}
 
 The scene above uses an `eventSubscriber` to initiate a listener that checks for click events done on the `redButton` entity. Whenever this occurs, the state of `buttonState` is toggled.
 
@@ -101,6 +105,7 @@ The scene above uses an `eventSubscriber` to initiate a listener that checks for
 
 The pointer down and pointer up events are fired whenever the user presses or releases an input controler. This could be a mouse, a touch screen, a VR controller or another kind of controller. It doesn't matter where the user's avatar is pointing at, the event is triggered every time.
 
+{% raw %}
 ```tsx
 import { createElement, ScriptableScene } from 'metaverse-api'
 
@@ -122,14 +127,15 @@ export default class bigButton extends ScriptableScene {
     return (
       <scene>
           <box id="button" 
-              position={ { x: 3, y: this.state.buttonState, z: 3 } } 
-              transition={ { position: { duration: 200, timing: "linear" } } } 
+              position={{ x: 3, y: this.state.buttonState, z: 3 }} 
+              transition={{ position: { duration: 200, timing: "linear" }}} 
           />
       </scene>
     )
   }
 }
 ```
+{% endraw %}
 
 The scene above uses two `subscribeTo` functions to initiate listeners that check both when the user clicks or releases a pointer button. Both listener functions alter the `buttonState` state variable in the scene. This variable is then used to set the height of a box that mimics the pressing of the user's button.
 
@@ -143,7 +149,7 @@ The `positionChanged` event has the following properties:
 * `cameraPosition`: a Vector3Component with the user's absolute position relative to the world.
 * `playerHeight`: the eye height of the user, in meters.
 
-
+{% raw %}
 ```tsx
 import { createElement, ScriptableScene } from 'metaverse-api'
 
@@ -167,6 +173,7 @@ export default class BoxFollower extends ScriptableScene {
   }
 }
 ```
+{% endraw %}
 
 The scene above uses a `subscribeTo` function to initiate a listener to track when the position of the user changes. When the user moves, the scene stores the current position in the state variable `boxPosition`, which is used to set the position of a box that follows the user around.
 
@@ -182,12 +189,12 @@ The `rotationChanged` event has the following properties:
 
 * `quaternion`: the rotation of the user expressed as a quaternion.
 
-
+{% raw %}
 ```tsx
 import { createElement, ScriptableScene } from 'metaverse-api'
 
 export default class ConeHead extends ScriptableScene {
-  state = { rotation: { x: 0, y: 0, z: 0 } }
+  state = { rotation: { x: 0, y: 0, z: 0 }}
 
   async sceneDidMount() {
       this.subscribeTo('positionChanged', e => {
@@ -199,12 +206,13 @@ export default class ConeHead extends ScriptableScene {
   async render() {
     return (
       <scene>
-      <cone position={ { x: 0, y: 1, z: 2 } } rotation={this.state.rotation}/>
+      <cone position={{ x: 0, y: 1, z: 2 }} rotation={this.state.rotation}/>
       </scene>
     )
   }
 }
 ```
+{% endraw %}
 
 The scene above uses a `subscribeTo` function to initiate a listener to track the user's rotation. When the user looks in a different direction, the scene stores the current angle in the state variable `rotation`. This example adds another 90 degrees to the X axis of this angle just to make the output more fun to play with. This angle is used to orient a cone that faces and mimics the user.
 

--- a/_posts/sdk-reference/2018-01-21-scene-content-guide.md
+++ b/_posts/sdk-reference/2018-01-21-scene-content-guide.md
@@ -42,14 +42,15 @@ See [Entity interfaces]({{ site.baseurl }}{% post_url /sdk-reference/2018-06-21-
 
 All entities can have a position, a rotation and a scale. These can be easily set as components, as shown below:
 
-
+{% raw %}
 ```xml
 <box
-    position={ { x: 5, y: 3, z: 5 } }
-    rotation={ { x: 180, y: 90, z: 0 } }
+    position={{ x: 5, y: 3, z: 5 }}
+    rotation={{ x: 180, y: 90, z: 0 }}
     scale={0.5}
   />
 ```
+{% endraw %}
 
 * `position` is a *3D vector*, it sets the position on all three axes. 
 * `rotation` is a *3D vector* too, but where each component represents the rotation in that axis.
@@ -59,16 +60,18 @@ When an entity is nested inside another, the child entities inherit components f
 
 You can include an invisible base entity to wrap a set of other entities and define their positioning as a group.
 
+{% raw %}
 ```xml
   <entity
-      position={ { x: 0, y: 0, z: 1 } }
-      rotation={ { x: 45, y: 0, z: 0 } }
+      position={{ x: 0, y: 0, z: 1 }}
+      rotation={{ x: 45, y: 0, z: 0 }}
   >
-    <box position={ { x: 10, y: 0, z: 0 } } scale={2} />
-    <box position={ { x: 10, y: 10, z: 0 } } scale={1} />
-    <box position={ { x: 0, y: 10, z: 0 } } scale={2} />
+    <box position={{ x: 10, y: 0, z: 0 }} scale={2} />
+    <box position={{ x: 10, y: 10, z: 0 }} scale={1} />
+    <box position={{ x: 0, y: 10, z: 0 }} scale={2} />
   </entity>
 ```
+{% raw %}
 
 You can also set a position, rotation and scale for the entire <scene/> entity and affect everything in the scene.
 
@@ -81,13 +84,15 @@ In dynamic scenes, you can configure an entity to affect the way in which it mov
 
 The example below shows a box entity that is configured to rotate smoothly. 
 
-
+{% raw %}
 ```xml
  <box 
     rotation={currnetRotation}
-    transition={ { rotation: { duration: 1000, timing: "ease-in" } } }
+    transition={{ rotation: { duration: 1000, timing: "ease-in" }}}
   />
 ```
+{% endraw %}
+
 > Note: The transition component doesn't make the box rotate, it just sets the way it rotates whenever the value of the entity's rotation changes, usually as the result of an event.
 
 The transition component can be added to affect the following properties of an entity:
@@ -99,18 +104,20 @@ The transition component can be added to affect the following properties of an e
 
 Note that the transition for each of these properties is configured separately.
 
+{% raw %}
 ```xml
  <box 
     rotation={currnetRotation}
     color={currnetColor}
     scale={currnetScale}
     transition={ 
-        { rotation: { duration: 1000, timing: "ease-in" } }
-        { color: { duration: 3000, timing: "exponential-in" } }
-        { scale: { duration: 300, timing: "bounce-in" } }
+        { rotation: { duration: 1000, timing: "ease-in" }}
+        { color: { duration: 3000, timing: "exponential-in" }}
+        { scale: { duration: 300, timing: "bounce-in" }}
         }
   />
 ```
+{% endraw %}
 
 The transition component allows you to set:
 
@@ -120,29 +127,33 @@ The transition component allows you to set:
 
 In the example below, a transition is applied to the rotation of an invisible entity that wraps a box. As the box is off-center from the parent entity, the box pivots like an opening door.
 
+{% raw %}
 ```xml
 
 <entity 
     rotation={currentRotation}  
-    transition={ { rotation: { duration: 1000, timing: "ease-in" } } }>
+    transition={{ rotation: { duration: 1000, timing: "ease-in" }}}>
         <box 
           id="door" 
-          scale={ { x: 1, y: 2, z: 0.05 } } 
-          position={ { x: 0.5, y: 1, z: 0 } } 
+          scale={{ x: 1, y: 2, z: 0.05 }} 
+          position={{ x: 0.5, y: 1, z: 0 }} 
         />
 </entity>
 ```
+{% endraw %}
 
 ## Color
 
 Color is set in hexadecimal values. To set an entity's color, simply set its `color` component to the corresponding hexadecimal value.
 
+{% raw %}
 ```xml
   <sphere 
-    position={ { x: 0.5, y: 1, z: 0 } }   
+    position={{ x: 0.5, y: 1, z: 0 }}   
     color="#EF2D5E"
   />
 ```
+{% endraw %}
 
 > Tip: There are many online color-pickers you can use to find a specific color graphically. To name one, you can try the color picker on [W 3 Schools](https://www.w3schools.com/colors/colors_picker.asp).
 
@@ -153,11 +164,12 @@ Materials are defined as separate entities in a scene, this prevents material de
 
 Materials can be applied to primitive entities and to planes, simply by setting the `material` component.
 
-
+{% raw %}
 ```tsx
   <material id="reusable_material" albedoColor="materials/wood.png" roughness="0.5" />
   <sphere material="#reusable_material" />
 ```
+{% endraw %}
 
 Materials are also implicitly imported into a scene when you import a gtLF model that includes embedded materials. When that's the case, the scene doesn't need a `<material/>` entity declared.
 
@@ -174,14 +186,15 @@ To add an external model into a scene, add a `<gltf-model>` element and set its 
 > Tip: We recommend keeping your models separate in a `/models` folder inside your scene.
 
 
-
+{% raw %}
 ```xml
 <gltf-model
-    position={ { x: 5, y: 3, z: 5 } }
+    position={{ x: 5, y: 3, z: 5 }}
     scale={0.5}
     src="models/myModel.gltf"
   />
 ```
+{% endraw %}
 
 glTF models can have either a `.gltf` or a `.glb` extension. glTF files are human-readable, you can open one in a text editor and read it like a JSON file. This is useful, for example, to verify that animations are properly attached and their names. glb files are binary, so they're not readable but they are considerably smaller in size, which is good for the scene's performance. 
 
@@ -203,9 +216,10 @@ In a dynamic scene, you reference an animation by its armature name, an undersco
 
 The example below imports a model that includes animations and configures them:
 
+{% raw %}
 ```xml
 <gltf-model
-    position={ { x: 5, y: 3, z: 5 } }
+    position={{ x: 5, y: 3, z: 5 }}
     scale={0.5}
     src="models/shark_anim.gltf"
     skeletalAnimation={[
@@ -214,6 +228,8 @@ The example below imports a model that includes animations and configures them:
     ]}
   />
 ```
+{% endraw %}
+
 In this example, the armature is named `shark_skeleton` and the two animations contained in it are named `bite` and `swim`.
 
 An animation can be set to loop continuously by setting its `loop` property. If `loop:false` then the animation will be called only once when activated.
@@ -299,15 +315,16 @@ how to add collider meshes into GLTF models
 
 Entities that have collision disabled can walked through by a user`s avatar, entities that do have collisions enabled occupy space and block a user's path.
 
-
+{% raw %}
 ```tsx
 <box 
-  position={ { x: 10, y: 0, z: 0 } } 
+  position={{ x: 10, y: 0, z: 0 }} 
   scale={2} 
   ignoreCollisions="false"
 />
 
 ```
+{% endraw %}
 
 The example above defines a box entity that can't be walked through.
 
@@ -352,17 +369,19 @@ plain text.
 
 The static scene above becomes the following dynamic schen when migrating it to TSX:
 
+{% raw %}
 ```tsx
 class Scene extends ScriptableScene {
   async render() {
     return (
       <scene>
-        <box position={ { x: 10, y: 10, z: 10 } } />
+        <box position={{ x: 10, y: 10, z: 10 }} />
       </scene>
     );
   }
 }
 ```
+{% endraw %}
 
 #### Attribute naming
 
@@ -372,15 +391,19 @@ class Scene extends ScriptableScene {
 
 HTML and XHTML are case insensitive for attributes, this generates conflicts with the implementation of certain attributes like `albedoColor`. Because reading `albedocolor` was confusing, and having hardcoded keys with hyphens in the code was so dirty, we decided to follow the React convention of having every property camel cased in code and hyphenated in the HTML/XML representation. 
 
+{% raw %}
 ```xml
 <scene>
   <!-- XML -->
   <material id="test" albedo-color="#ffeeaa" />
 </scene>
 ```
+{% endraw %}
 
 The static scene above becomes the following dynamic schen when migrating it to TSX:
 
+
+{% raw %}
 ```tsx
 <!-- TSX -->
 class Scene extends ScriptableScene {
@@ -393,3 +416,4 @@ class Scene extends ScriptableScene {
   }
 }
 ```
+{% endraw %}

--- a/_posts/sdk-reference/2018-06-21-entity-interfaces.md
+++ b/_posts/sdk-reference/2018-06-21-entity-interfaces.md
@@ -39,6 +39,7 @@ Creates a cube geometry.
 
 Example:
 
+{% raw %}
 ```tsx
 <box 
   position={ { x: 5, y: 0, z: 2 } } 
@@ -46,6 +47,8 @@ Example:
   scale={2} 
 />
 ```
+{% endraw %}
+
 
 Interface reference:
 
@@ -66,13 +69,16 @@ Creates a sphere geometry.
 
 Example:
 
+
+{% raw %}
 ```tsx
 <sphere 
-  position={ { x: 5, y: 0, z: 2 } } 
+  position={{ x: 5, y: 0, z: 2 }} 
   color="#ff00aa" 
   scale={2} 
 />
 ```
+{% endraw %}
 
 Interface reference:
 
@@ -97,17 +103,19 @@ Creates a plane geometry.
 
 Example:
 
+{% raw %}
 ```tsx
 <plane 
-  position={ { x: 5, y: 0, z: 2 } } 
+  position={{ x: 5, y: 0, z: 2 }} 
   color="#ff00aa" 
-  scale={ { x: 10, y: 5, z: 1 } } 
+  scale={{ x: 10, y: 5, z: 1 }} 
 />
 ```
+{% endraw %}
 
 Interface reference:
 
-
+{% raw %}
 ```tsx
 interface PlaneEntity extends BaseEntity {
   /** Color of the vertices */
@@ -119,8 +127,8 @@ interface PlaneEntity extends BaseEntity {
   /** Set to true to turn off the collider for the entity. */
   ignoreCollisions?: boolean
 }
-
 ```
+{% endraw %}
 
 ## Cylinder and Cone
 
@@ -205,20 +213,22 @@ The `gltf-model` entity loads a 3D model using a glTF file. It supports both `.g
 
 Simple example:
 
+{% raw %}
 ```tsx
   <gltf-model
-    position={ { x: 5, y: 3, z: 5 } }
+    position={{ x: 5, y: 3, z: 5 }}
     scale={0.5}
     src="models/shark_anim.gltf"
   />
 ```
-
+{% endraw %}
 
 Example with animations:
 
+{% raw %}
 ```tsx
   <gltf-model
-    position={ { x: 5, y: 3, z: 5 } }
+    position={{ x: 5, y: 3, z: 5 }}
     scale={0.5}
     src="models/shark_anim.gltf"
     skeletalAnimation={[
@@ -227,7 +237,7 @@ Example with animations:
     ]}
   />
 ```
-
+{% endraw %}
 
 Interface reference:
 
@@ -275,12 +285,14 @@ The `BaseEntity` interface is the most flexible of all, as it comes with no pred
 
 Example:
 
+{% raw %}
 ```tsx
   <entity 
-    position={ { x: 2, y: 1, z: 0 } } 
-    scale={ { x: 2, y: 2, z: 0.0  5 } }
+    position={{ x: 2, y: 1, z: 0 }} 
+    scale={{ x: 2, y: 2, z: 0.0  5 }}
   />
 ```
+{% endraw %}
 
 You add a base entity to a scene via the XML tag `<entity>`. You can add an entity with no components to a scene to act as a container. The `<entity>` element has no components by default, so it's invisible and has no direct effect on the scene, but it can be positioned, scaled, and rotated and it can contain other child entities in it. Child entities are scaled, rotated, and positioned relative to the parent entity. 
 


### PR DESCRIPTION
@eordano  please review and merge


A couple of samples on the last page we published were displaying incomplete code because it had {{ and }}

I decided to add {% raw %} on all code samples that included this, on other pages too, so that the code looks nicer than the with old workaround we were using