### PR TITLE
docs: added missing endpoints + a few corrections

### DIFF
--- a/_posts/marketplace/2018-01-01-api.md
+++ b/_posts/marketplace/2018-01-01-api.md
@@ -9,7 +9,7 @@ set: marketplace
 set_order: 2
 ---
 
-Base URL:  `https://api.decentraland.org/`
+Base URL: `https://api.decentraland.org/`
 
 Specify version: `https://api.decentraland.org/v1`
 
@@ -117,7 +117,7 @@ Returns a list of Estates, paginated, sorted, and filtered according to the quer
 
 | name       | type | default              | description                                                                          |
 | ---------- | ---- | -------------------- | ------------------------------------------------------------------------------------ |
-| status     | enum | `open`               | Filter parcels by publications status: `open`, `cancelled` or `sold`                 |
+| status     | enum | `open`               | Filter estates by publications status: `open`, `cancelled` or `sold`                 |
 | sort_by    | enum | `created_at`         | Property to order by: `price`, `created_at`, `block_time_updated_at` or `expires_at` |
 | sort_order | enum | depends on `sort_by` | The order to sort by: `asc` or `desc`                                                |
 | limit      | int  | `20`                 | The number of results to be retuned                                                  |
@@ -146,6 +146,43 @@ Returns all the Estates that belong to a given address
 | address | string | An Ethereum address |
 
 ## Map
+
+```
+GET /map
+```
+
+### Description
+
+Returns all the parcels and estates in a given area
+
+### Query Params
+
+| name | type | min  | max | description                     |
+| ---- | ---- | ---- | --- | ------------------------------- |
+| nw   | int  | -150 | 150 | The northwest coord of the area |
+| se   | int  | -150 | 150 | The southeast coord of the area |
+
+### Request Example:
+
+```
+GET /map?nw=-10,10&se=10,-10
+```
+
+### Result:
+
+```js
+{
+  "data": {
+    "assets": {
+      "parcels": [/* parcels */],
+      "estates": [/* estates */]
+    },
+    "total": 441
+  }
+}
+```
+
+---
 
 ```
 GET /map.png
@@ -227,6 +264,49 @@ GET /parcels/-36/-125/map.png?height=500&width=500&size=10&publications=true
 ### Result:
 
 ![map-1](https://user-images.githubusercontent.com/2781777/41127253-9f1af8a0-6a80-11e8-9b26-ba630c85871c.png)
+
+---
+
+```
+GET /estates/:id/map.png
+```
+
+### Description
+
+Same as `/parcels/:x/:y/map.png`, but instead of using `x` and `y` coordinates to determine the estate, its `id` is used.. Returns a PNG of a piece of the map center on a given estate
+
+### URI Params
+
+| name | type   | description          |
+| ---- | ------ | -------------------- |
+| id   | string | The id of the estate |
+
+### Query Params
+
+| name         | type    | min | max  | default | description                                                               |
+| ------------ | ------- | --- | ---- | ------- | ------------------------------------------------------------------------- |
+| width        | int     | 32  | 2048 | 500     | The width of the PNG image in pixels                                      |
+| height       | int     | 32  | 2048 | 500     | The height of the PNG image in pixels                                     |
+| size         | int     | 5   | 40   | 10      | The size of each parcel (i.e. 10 will render each parcel as 10x10 pixels) |
+| publications | boolean | N/A | N/A  | false   | If true, parcels that are on sale are highlighted                         |
+
+### Limits
+
+There's a limit of 15,000 parcels that can be rendered in a single PNG, if a request goes above this threshold the API will return a 500 with a message like this:
+
+```
+Too many parcels. You are trying to render 42436 parcels and the maximum allowed is 15000.
+```
+
+### Request Example:
+
+```
+GET /estates/znfhqr7s4g00000000000000000000000000000000/map.png?height=500&width=500&size=10&publications=true
+```
+
+### Result:
+
+![map-2](https://user-images.githubusercontent.com/692077/42239793-534b4878-7f05-11e8-9f3b-2860693433ef.png)
 
 ---
 
@@ -315,6 +395,16 @@ GET /addresses/:address/parcels
 ### Description
 
 Returns all the parcels that belong to a given address
+
+---
+
+```
+GET /parcels/:x/:y
+```
+
+### Description
+
+Returns a single parcel by its coords
 
 ## Publications
 


### PR DESCRIPTION
This PR adds a few missing endpoints:

- `/map`

- `/estates/:id/map.png`

- `/parcels/:x/:y`

And it also corrects a wrong description