### PR TITLE
Added GET /estates response example

### DIFF
--- a/_posts/blockchain-interactions/2018-01-01-api.md
+++ b/_posts/blockchain-interactions/2018-01-01-api.md
@@ -124,7 +124,50 @@ Returns a list of Estates, paginated, sorted, and filtered according to the quer
 ### Response Example
 
 ```json
-//TODO: Add `Response Example`
+{
+  "ok": true,
+  "data": {
+    "estates": [
+      {
+        "id": "12345",
+        "owner": "0xe0653744f2d6a388f1fc7496e085156418a9f5ed",
+        "data": {
+          "ipns": "",
+          "name": "My Estate",
+          "parcels": [
+            { "x": -30, "y": -121 },
+            { "x": -29, "y": -121 },
+            { "x": -29, "y": -122 },
+            { "x": -30, "y": -122 }
+          ],
+          "version": 0,
+          "description": "My estate is awesome"
+        },
+        "last_transferred_at": "1548929430000",
+        "tx_hash": "0x6d1f7cad7419af31b6b1f65205c5336200a1662e35ed9083d5f4323f95cb9dd6",
+        "token_id": "12345",
+        "update_operator": "0x0000000000000000000000000000000000000000",
+        "publication": {
+          "tx_hash": "0xbcad5e05351972174c05633e8965de0b05a5a0ce4c5415c1a392ffae20b1cab2",
+          "tx_status": "confirmed",
+          "owner": "0xf631c1ba09ee33e7649cac62ccb6d0f410f5647a",
+          "price": 39500,
+          "expires_at": 1554210000000,
+          "status": "sold",
+          "buyer": "0xe0653744f2d6a388f1fc7496e085156418a9f5ed",
+          "contract_id": "0xfe8288241f94ebf31c132b85eb9ee6b834fb27b4c564eab6ba18b3813fafda38",
+          "block_number": 7151964,
+          "block_time_created_at": 1548906378000,
+          "block_time_updated_at": 1548929430000,
+          "asset_type": "estate",
+          "asset_id": "12345",
+          "marketplace_address": "0x8e5660b4ab70168b5a6feea0e0315cb49c8cd539"
+        }
+      }
+    ],
+    "total": 80
+  }
+}
 ```
 
 ```


### PR DESCRIPTION
I noticed the "//TODO: Add `Response Example`" under GET /estates.  I provided a semi-mocked example. Based on a real call, I altered some of the addresses.