### PR TITLE
Made the symlink again

### DIFF
--- a/vendor/bundle/ruby/2.3.0/gems/ffi-1.9.25/ext/ffi_c/libffi-universal-darwin18/include/ffitarget.h
+++ b/vendor/bundle/ruby/2.3.0/gems/ffi-1.9.25/ext/ffi_c/libffi-universal-darwin18/include/ffitarget.h
@@ -1,1 +1,1 @@
-/Users/Nico/Documents/github/documentation/vendor/bundle/ruby/2.3.0/gems/ffi-1.9.25/ext/ffi_c/libffi/src/x86/ffitarget.h
+../../libffi/src/x86/ffitarget.h


### PR DESCRIPTION
Modified the symlink from 
 ffitarget.h -> /Users/Nico/Documents/github/documentation/vendor/bundle/ruby/2.3.0/gems/ffi-1.9.25/ext/ffi_c/libffi/src/x86/ffitarget.h

to
ffitarget.h -> ../../libffi/src/x86/ffitarget.h