### PR TITLE
Added "Packing your item" title

### DIFF
--- a/_posts/development-guide/2020-02-20-smart-items.md
+++ b/_posts/development-guide/2020-02-20-smart-items.md
@@ -376,7 +376,7 @@ Then simply run `dcl start` on the item's folder, as you would for a normal scen
 
 Try providing different values to the item's properties, to make sure it functions as expected.
 
-## Packing your item
+## Importing into the Builder
 
 When you're ready to export the item, run `dcl pack` on the item's folder. This will generate an `item.zip` file. Then import this file into a custom asset pack in the Builder.
 

--- a/_posts/development-guide/2020-02-20-smart-items.md
+++ b/_posts/development-guide/2020-02-20-smart-items.md
@@ -376,6 +376,8 @@ Then simply run `dcl start` on the item's folder, as you would for a normal scen
 
 Try providing different values to the item's properties, to make sure it functions as expected.
 
+## Packing your item
+
 When you're ready to export the item, run `dcl pack` on the item's folder. This will generate an `item.zip` file. Then import this file into a custom asset pack in the Builder.
 
 You can then test it in a Builder scene. We recommend you do the following tests:


### PR DESCRIPTION
Information about how to pack the item was difficult to find, It was in the unrelated "Testing your item" section.