### PR TITLE
Improvements on sound Looping section

### DIFF
--- a/_posts/development-guide/2018-02-10-sounds.md
+++ b/_posts/development-guide/2018-02-10-sounds.md
@@ -52,11 +52,11 @@ If you set the `playing` property of an `AudioSource` component to _false_, the 
 
 ## Looping
 
-To keep a sound playing in a continuous loop, set the `loop` field of the `AudioSource` component to _true_.
+To keep a sound playing in a continuous loop, set the `loop` field of the `AudioSource` component to _true_ before start playing it.
 
 ```ts
-source.play = true
 source.loop = true
+source.playing = true
 ```
 
 Looping sounds is especially useful for adding background music or other background sounds.

--- a/_posts/development-guide/2018-02-10-sounds.md
+++ b/_posts/development-guide/2018-02-10-sounds.md
@@ -52,7 +52,7 @@ If you set the `playing` property of an `AudioSource` component to _false_, the 
 
 ## Looping
 
-To keep a sound playing in a continuous loop, set the `loop` field of the `AudioSource` component to _true_ before start playing it.
+To keep a sound playing in a continuous loop, set the `loop` field of the `AudioSource` component to _true_ before you start playing it.
 
 ```ts
 source.loop = true


### PR DESCRIPTION
The "play" property does not exists. It is named "playing".
Also to properly loop a sound you need to set the loop property before playing it.