### PR TITLE
Update 2020-03-16-builder-101.md

### DIFF
--- a/_posts/builder/2020-03-16-builder-101.md
+++ b/_posts/builder/2020-03-16-builder-101.md
@@ -37,8 +37,8 @@ Navigate the themed asset pack categories on the menu on the right to find diffe
 
 To place an item:
 
-- Click and drag the item a specific location in the scene
-- Click on them in the menu, it will appear in a random location in the scene.
+- Click and drag the item to a specific location in the scene.
+- Click on the item in the menu, it will appear in a random location in the scene.
 
 ## Position items
 
@@ -52,9 +52,9 @@ To rotate an item, select the _Rotate tool_ on the top menu. A gizmo appears on 
 
 To make an item larger or smaller, select the _scale_ item on the top menu, then click on the center of the gizmo and drag in or out. This tool also lets you stretch an item in a single axis to change its proportions, to do this click on one of the axis of the gizmo and drag it.
 
-> TIP: To have greater precision while moving, rotating or scaling an item, press and hold the _Shift_ key while making adjustments.
+> Tip: To have greater precision while moving, rotating or scaling an item, press and hold the _Shift_ key while making adjustments.
 
-To delete and item from the scene, select it and click the _Delete_ tool.
+To delete an item from the scene, select it and click the _Delete_ tool.
 
 To duplicate an item, select it and click the _Duplicate_ tool. The new item will be perfectly overlapping the original.
 
@@ -72,7 +72,7 @@ Note that 3d models have bounding boxes that surround them. Sometimes, even thou
 
 If you imported a custom 3D model that has bounding boxes that extend far beyond the model itself, it's a good practice to edit the model to make sure the bounding boxes extend out as little as possible. See [Meshes]({{ site.baseurl }}{% post_url /3d-modeling/2018-01-11-meshes %}#bounding-boxes).
 
-To keep scenes in decentraland lightweight, you are limited to a maximum amount of textures, triangles, etc. See [scene limitations]({{ site.baseurl }}{% post_url /builder/2020-03-16-scene-limitations %}).
+To keep scenes in Decentraland lightweight, you are limited to a maximum amount of textures, triangles, etc. See [scene limitations]({{ site.baseurl }}{% post_url /builder/2020-03-16-scene-limitations %}).
 
 ## Preview
 


### PR DESCRIPTION
Small punctuation, grammatical, and spelling errors. Changed "TIP:" to "Tip:" to maintain consistency with capitalization on other Decentraland documentation pages.