### PR TITLE
Fix: Correct link to LAND manager

### DIFF
--- a/_posts/market/2020-02-16-land-manager.md
+++ b/_posts/market/2020-02-16-land-manager.md
@@ -9,7 +9,7 @@ type: Document
 
 The Land Manager allows you to manage your LAND and Estate assets.
 
-Access the Land manager at [https://land.decentraland.org](land.decentraland.org)
+Access the Land manager at [https://land.decentraland.org](https://land.decentraland.org)
 
 The Land Manager allows you to:
 


### PR DESCRIPTION
Link was redirecting to
`https://docs.decentraland.org/market/land-manager/land.decentraland.org`
instead of
`https://land.decentraland.org`