### PR TITLE
2021-05-31-creating-wearables.md - Resolve Triangle Count Figure

### DIFF
--- a/_posts/wearables/2021-05-31-creating-wearables.md
+++ b/_posts/wearables/2021-05-31-creating-wearables.md
@@ -111,7 +111,7 @@ The same goes for textures. It’s critical that we use as few textures as possi
 
 There are limits for the number of triangles and textures that can be used for each wearable or accessory:
 
-- No more than 1K triangles per wearable
+- No more than 1.5K triangles per wearable
 - No more than 500 triangles per accessories
 - No more than 2 textures (at a resolution of 512x512px or lower) per wearable. All textures must be square.
 


### PR DESCRIPTION
Taking a look at line 56 in 2021-05-31-publishing-wearables.md the triangles quoted are 1500 as a max. Which one is correct? One will need to be updated.