### PR TITLE
Fix SDK 101 article code snippets formatting

### DIFF
--- a/_posts/development-guide/2020-03-16-SDK-101.md
+++ b/_posts/development-guide/2020-03-16-SDK-101.md
@@ -173,18 +173,14 @@ To use any of the helpers provided by the Utils library:
 
 2. Run one of the following for the scene to build the necessary files inside the library's folder:
 
+   ```
    dcl build
-
    ```
 
    or
 
    ```
-
    dcl start
-
-   ```
-
    ```
 
 3. Import the library into the scene's script. Add this line at the start of your `game.ts` file, or any other TypeScript files that require it:


### PR DESCRIPTION
The [SDK 101](https://docs.decentraland.org/development-guide/SDK-101/) article has some snippets with an erroneous formatting. This CR fixes that.

See bad formatting screenshot below:

![image](https://user-images.githubusercontent.com/2617411/140769666-a6646688-fb71-4424-a4ae-96d2cfff5214.png)
