### PR TITLE
Link to Wearables Editor User Guide

### DIFF
--- a/_posts/wearables/2021-05-31-publishing-wearables.md
+++ b/_posts/wearables/2021-05-31-publishing-wearables.md
@@ -8,7 +8,7 @@ categories:
 type: Document
 ---
 
-For detailed instructions on how to submit your wearable collection for approval before publication, see the User Guide. This document explains how the approval process works when publishing wearables, and what criteria is used by the Curation Committee when reviewing wearables. For detailed information on the Curation Committee, [start here]({{ site.baseurl }}{% post_url /wearables/2021-05-31-curation-committee %}).
+For detailed instructions on how to submit your wearable collection for approval before publication, see the [User Guide](https://docs.decentraland.org/decentraland/wearables-editor-user-guide/). This document explains how the approval process works when publishing wearables, and what criteria is used by the Curation Committee when reviewing wearables. For detailed information on the Curation Committee, [start here]({{ site.baseurl }}{% post_url /wearables/2021-05-31-curation-committee %}).
 
 ### The publication process
 


### PR DESCRIPTION
Some users sent to this Publishing Wearables page didn't realize they need to click over the Curation Committee side-bar menu to get to the steps for creating your collection and getting it ready to publish with the Wearbles Editor User Guide link.

It says User Guide in the side-bar, but this should help get everyone that might have the window half-screen and the sidebar hidden.