### PR TITLE
Changing nodejs required version for CLI

### DIFF
--- a/_posts/development-guide/2020-03-16-SDK-101.md
+++ b/_posts/development-guide/2020-03-16-SDK-101.md
@@ -17,7 +17,7 @@ The CLI allows you to compile and preview your scene locally. After testing your
 
 > **Note**: Install the following dependencies before you install the CLI:
 >
-> - [Node.js](https://nodejs.org/) (version 8 or later)
+> - [Node.js](https://nodejs.org/) (version 14 or later)
 
 To install the CLI, run the following command in your command line tool of choice:
 


### PR DESCRIPTION
`dcl init` uses optional chaining so having a nodejs version lower than 14 will throw an error

## Lower version than 14

![image](https://user-images.githubusercontent.com/4969737/157315834-61b1bced-ddf1-4f26-a1fd-079ea76e9179.png)

## Higher version than 14

![image](https://user-images.githubusercontent.com/4969737/157315984-cdc5c872-dbd5-4446-8714-f6d691a405b2.png)
