### PR TITLE
UIImage.data => UIImage.source

### DIFF
--- a/_posts/development-guide/2018-02-15-onscreen-ui.md
+++ b/_posts/development-guide/2018-02-15-onscreen-ui.md
@@ -270,10 +270,10 @@ expandButton.sourceWidth = 128
 expandButton.sourceHeight = 128
 ```
 
-You can change the texture being used by an existing `UIImage` component, set the `data` field.
+You can change the texture being used by an existing `UIImage` component, set the `source` field.
 
 ```ts
-playButton.data = imageTexture2
+playButton.source = imageTexture2
 ```
 
 ## Clicking UI elements


### PR DESCRIPTION
The existing documentation was incorrect, `UIImage.data = x` does not update the texture to `x` - however `UIImage.source = x` does