### PR TITLE
Updated 2018-02-6-shape-components.md - removed google poly link

### DIFF
--- a/_posts/development-guide/2018-02-6-shape-components.md
+++ b/_posts/development-guide/2018-02-6-shape-components.md
@@ -69,7 +69,6 @@ Instead of building your own 3d models, you can also download them from several 
 To get you started, below is a list of libraries that have free or relatively inexpensive content:
 
 - [Assets from the Builder](https://github.com/decentraland/builder-assets/tree/master/assets)
-- [Google Poly](https://poly.google.com)
 - [SketchFab](https://sketchfab.com/)
 - [Clara.io](https://clara.io/)
 - [Archive3D](https://archive3d.net/)


### PR DESCRIPTION
As Google Poly has been shut down, removing the link from the documentation