### PR TITLE
fix: Change thumbnail requirements to be 1024x1024

### DIFF
--- a/_posts/development-guide/2022-02-02-smart-wearables.md
+++ b/_posts/development-guide/2022-02-02-smart-wearables.md
@@ -7,7 +7,6 @@ categories:
 type: Document
 ---
 
-
 > **WARNING:** Smart wearables are still in Alpha. The Builder does not support the upload of smart wearables, and there isn't an approval process in place to allow community-built smart wearables to be published. The current development tools allow you to create and test smart wearables, but please don't attempt to publish any in the Builder, they will not be approved.
 
 Smart wearables are a type of portable experience. Portable experiences are parts of the gameplay that players take with them as they move through the metaverse. For example, a player could take a snowball from your scene, walk away to another scene, and throw the snowball to another player who’s also playing the same game.
@@ -103,7 +102,7 @@ The following fields are present in `asset.json`:
   - epic (1000 copies)
   - uncommon (10.000 copies)
   - common (100.000 copies)
-- `thumbnail`: Image to use as thumbnail for the wearable, both in the backpack and the marketplace. This image should be at root level in your folder. The recommended image size is 256x256.
+- `thumbnail`: Image to use as thumbnail for the wearable, both in the backpack and the marketplace. This image should be at root level in your folder. The recommended required image size is 1024x1024.
 - `menuBarIcon`: Image to use on the “experiences” menu, to represent this portable experience, to represent the portable experience. This image should be at root level in your folder. The recommended image size is 256x256.
 - `model`: The 3d model to use for the wearable. This file should be at root level in your folder.
 - `bodyShape`: The avatar body type that this wearable is compatible with. Possible values:

--- a/_posts/wearables/2021-05-31-wearables-editor-user-guide.md
+++ b/_posts/wearables/2021-05-31-wearables-editor-user-guide.md
@@ -154,7 +154,7 @@ Tags are simply descriptive words that users can use when searching or filtering
 
 You can upload your own custom thumbnails for wearables in your collections. To upload a custom thumbnail image, navigate to the Wearables Editor and open the item you want to add a thumbnail for. Click **Edit** and then click on the thumbnail image under details to upload an image from your computer (a camera icon will appear when you hover over the thumbnail).
 
-> Thumbnails must be 256px by 256px with transparent backgrounds. Collections containing thumbnails without transparent backgrounds will not be accepted by the Curation Committee.
+> Thumbnails must be 1024px by 1024px with transparent backgrounds. Collections containing thumbnails without transparent backgrounds will not be accepted by the Curation Committee.
 >
 > <img width="1132" alt="custom thumbnail" src="{{ site.baseurl }}/images/media/wearable-thumbnail.png">
 


### PR DESCRIPTION
Following the [changes done in the Catalyst for the V4](https://github.com/decentraland/adr/blob/main/docs/ADR-45-entities-v4.md) version of the entities, the thumbnails now need to be of size 1024x1024. This must be changed in the docs to fit the requirement.