### PR TITLE
fix: deploying your own transactions server menu link

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -171,7 +171,7 @@
             - title: Second layer
               post: "development-guide/2018-02-02-second-layer.md"
             - title: Deploying your own transactions server
-              post: "development-guide/2022-05-18-deploying-your-own-transactions-server"
+              post: "development-guide/2022-05-18-deploying-your-own-transactions-server.md"
         - title: Advanced
           children:
             - title: Game objects


### PR DESCRIPTION
I'm not entirely sure this is the error, but this PR is to fix the `Deploying your own transactions server` menu not having an href:
<img width="236" alt="image" src="https://user-images.githubusercontent.com/692077/174823367-0516409b-5f89-4361-bff9-76c32831e900.png">
<img width="476" alt="image" src="https://user-images.githubusercontent.com/692077/174823423-478a4bc9-68af-40f4-a7b1-5d69f2b55ffb.png">


And when entering the link: https://docs.decentraland.org/development-guide/deploying-your-own-transactions-server/
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/692077/174823278-be44045c-3117-434c-95a6-125b569a4642.png">
the menu is not highlighted ☝️ 