### PR TITLE
Fixed a bug in the doc for Raycasting using Systems.

### DIFF
--- a/_posts/development-guide/2018-02-27-raycasting.md
+++ b/_posts/development-guide/2018-02-27-raycasting.md
@@ -231,7 +231,7 @@ class RaycastSystem implements ISystem {
   }
 }
 
-engine.addSystem(RaycastSystem)
+engine.addSystem(new RaycastSystem())
 ```
 
 This example runs two raycast queries on every frame of the scene. Since they each have a different id, the requests from the first query and from the second query are handled on different queues that are independent from the other.


### PR DESCRIPTION
When calling engine.addSystem(RaycastSystem) it throws an error . So to fix that an instance of ISystem RaycastSystem should be passed into the method.