### PR TITLE
Update 2022-03-17-poap-tokens.md

### DIFF
--- a/_posts/development-guide/2022-03-17-poap-tokens.md
+++ b/_posts/development-guide/2022-03-17-poap-tokens.md
@@ -169,7 +169,7 @@ For simple implementations of the POAP booth:
 ```ts
 import { Dispenser } from "./booth/dispenser"
 
-const POAPBooth = new Dispenser(
+const POAPBooth = createDispenser(
   {
     position: new Vector3(8, 0, 8),
     rotation: Quaternion.Euler(0, 0, 0),


### PR DESCRIPTION
dispenser.ts does not contain a constructor. The function createDispenser serves the same purpose.